### PR TITLE
feat: expand form field support

### DIFF
--- a/c365-flow/src/components/formRenderer/fields/implementations/BarcodeField.tsx
+++ b/c365-flow/src/components/formRenderer/fields/implementations/BarcodeField.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Text, TextInput, View } from 'react-native';
+import type { FieldComponentProps } from '../types';
+
+export function BarcodeField({ field, value, onChange, onLayout, readOnly }: FieldComponentProps<string>) {
+  return (
+    <View onLayout={onLayout} style={{ marginBottom: 8 }}>
+      {field.label && <Text style={{ marginBottom: 4 }}>{field.label}</Text>}
+      <TextInput
+        value={value ?? ''}
+        editable={!readOnly}
+        onChangeText={onChange}
+        style={{ borderWidth: 1, borderColor: '#ccc', padding: 4 }}
+      />
+    </View>
+  );
+}

--- a/c365-flow/src/components/formRenderer/fields/implementations/BooleanField.tsx
+++ b/c365-flow/src/components/formRenderer/fields/implementations/BooleanField.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Switch, Text, View } from 'react-native';
+import type { FieldComponentProps } from '../types';
+
+export function BooleanField({ field, value, onChange, onLayout, readOnly }: FieldComponentProps<boolean>) {
+  return (
+    <View onLayout={onLayout} style={{ marginBottom: 8 }}>
+      {field.label && <Text style={{ marginBottom: 4 }}>{field.label}</Text>}
+      <Switch value={!!value} onValueChange={onChange} disabled={readOnly} />
+    </View>
+  );
+}

--- a/c365-flow/src/components/formRenderer/fields/implementations/CurrencyField.tsx
+++ b/c365-flow/src/components/formRenderer/fields/implementations/CurrencyField.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Text, TextInput, View } from 'react-native';
+import type { FieldComponentProps } from '../types';
+
+export function CurrencyField({ field, value, onChange, onLayout, readOnly }: FieldComponentProps<string>) {
+  return (
+    <View onLayout={onLayout} style={{ marginBottom: 8 }}>
+      {field.label && <Text style={{ marginBottom: 4 }}>{field.label}</Text>}
+      <TextInput
+        value={value ? String(value) : ''}
+        editable={!readOnly}
+        onChangeText={onChange}
+        keyboardType="decimal-pad"
+        style={{ borderWidth: 1, borderColor: '#ccc', padding: 4 }}
+      />
+    </View>
+  );
+}

--- a/c365-flow/src/components/formRenderer/fields/implementations/DateField.tsx
+++ b/c365-flow/src/components/formRenderer/fields/implementations/DateField.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Text, TextInput, View } from 'react-native';
+import type { FieldComponentProps } from '../types';
+
+export function DateField({ field, value, onChange, onLayout, readOnly }: FieldComponentProps<string>) {
+  return (
+    <View onLayout={onLayout} style={{ marginBottom: 8 }}>
+      {field.label && <Text style={{ marginBottom: 4 }}>{field.label}</Text>}
+      <TextInput
+        value={value ?? ''}
+        editable={!readOnly}
+        onChangeText={onChange}
+        placeholder="YYYY-MM-DD"
+        style={{ borderWidth: 1, borderColor: '#ccc', padding: 4 }}
+      />
+    </View>
+  );
+}

--- a/c365-flow/src/components/formRenderer/fields/implementations/DateTimeField.tsx
+++ b/c365-flow/src/components/formRenderer/fields/implementations/DateTimeField.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Text, TextInput, View } from 'react-native';
+import type { FieldComponentProps } from '../types';
+
+export function DateTimeField({ field, value, onChange, onLayout, readOnly }: FieldComponentProps<string>) {
+  return (
+    <View onLayout={onLayout} style={{ marginBottom: 8 }}>
+      {field.label && <Text style={{ marginBottom: 4 }}>{field.label}</Text>}
+      <TextInput
+        value={value ?? ''}
+        editable={!readOnly}
+        onChangeText={onChange}
+        placeholder="YYYY-MM-DD HH:MM"
+        style={{ borderWidth: 1, borderColor: '#ccc', padding: 4 }}
+      />
+    </View>
+  );
+}

--- a/c365-flow/src/components/formRenderer/fields/implementations/ImageSelectField.tsx
+++ b/c365-flow/src/components/formRenderer/fields/implementations/ImageSelectField.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import type { FieldComponentProps } from '../types';
+
+export function ImageSelectField({ field, value, onLayout }: FieldComponentProps<string>) {
+  return (
+    <View onLayout={onLayout} style={{ marginBottom: 8 }}>
+      {field.label && <Text style={{ marginBottom: 4 }}>{field.label}</Text>}
+      <Text>{value ? '1 image selected' : 'No image selected'}</Text>
+    </View>
+  );
+}

--- a/c365-flow/src/components/formRenderer/fields/implementations/MultiSelectField.tsx
+++ b/c365-flow/src/components/formRenderer/fields/implementations/MultiSelectField.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Text, TextInput, View } from 'react-native';
+import type { FieldComponentProps } from '../types';
+
+export function MultiSelectField({ field, value, onChange, onLayout, readOnly }: FieldComponentProps<string[]>) {
+  const joined = Array.isArray(value) ? value.join(', ') : '';
+  return (
+    <View onLayout={onLayout} style={{ marginBottom: 8 }}>
+      {field.label && <Text style={{ marginBottom: 4 }}>{field.label}</Text>}
+      <TextInput
+        value={joined}
+        editable={!readOnly}
+        onChangeText={(t) => onChange(t.split(',').map(s => s.trim()))}
+        style={{ borderWidth: 1, borderColor: '#ccc', padding: 4 }}
+      />
+    </View>
+  );
+}

--- a/c365-flow/src/components/formRenderer/fields/implementations/NumberField.tsx
+++ b/c365-flow/src/components/formRenderer/fields/implementations/NumberField.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Text, TextInput, View } from 'react-native';
+import type { FieldComponentProps } from '../types';
+
+type Props = FieldComponentProps<string> & { keyboardType?: any };
+
+export function NumberField({ field, value, onChange, onLayout, readOnly, keyboardType }: Props) {
+  return (
+    <View onLayout={onLayout} style={{ marginBottom: 8 }}>
+      {field.label && <Text style={{ marginBottom: 4 }}>{field.label}</Text>}
+      <TextInput
+        value={value ? String(value) : ''}
+        editable={!readOnly}
+        onChangeText={onChange}
+        keyboardType={keyboardType}
+        style={{ borderWidth: 1, borderColor: '#ccc', padding: 4 }}
+      />
+    </View>
+  );
+}

--- a/c365-flow/src/components/formRenderer/fields/implementations/PhotoField.tsx
+++ b/c365-flow/src/components/formRenderer/fields/implementations/PhotoField.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import type { FieldComponentProps } from '../types';
+
+export function PhotoField({ field, value, onLayout }: FieldComponentProps<string[]>) {
+  const count = Array.isArray(value) ? value.length : 0;
+  return (
+    <View onLayout={onLayout} style={{ marginBottom: 8 }}>
+      {field.label && <Text style={{ marginBottom: 4 }}>{field.label}</Text>}
+      <Text>{`${count} photo(s)`}</Text>
+    </View>
+  );
+}

--- a/c365-flow/src/components/formRenderer/fields/implementations/SelectField.tsx
+++ b/c365-flow/src/components/formRenderer/fields/implementations/SelectField.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Text, TextInput, View } from 'react-native';
+import type { FieldComponentProps } from '../types';
+
+export function SelectField({ field, value, onChange, onLayout, readOnly }: FieldComponentProps<string>) {
+  return (
+    <View onLayout={onLayout} style={{ marginBottom: 8 }}>
+      {field.label && <Text style={{ marginBottom: 4 }}>{field.label}</Text>}
+      <TextInput
+        value={value ?? ''}
+        editable={!readOnly}
+        onChangeText={onChange}
+        style={{ borderWidth: 1, borderColor: '#ccc', padding: 4 }}
+      />
+    </View>
+  );
+}

--- a/c365-flow/src/components/formRenderer/fields/implementations/SignatureField.tsx
+++ b/c365-flow/src/components/formRenderer/fields/implementations/SignatureField.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import type { FieldComponentProps } from '../types';
+
+export function SignatureField({ field, value, onLayout }: FieldComponentProps<string | null>) {
+  return (
+    <View onLayout={onLayout} style={{ marginBottom: 8 }}>
+      {field.label && <Text style={{ marginBottom: 4 }}>{field.label}</Text>}
+      <Text>{value ? 'Signature captured' : 'No signature'}</Text>
+    </View>
+  );
+}

--- a/c365-flow/src/components/formRenderer/fields/implementations/TextField.tsx
+++ b/c365-flow/src/components/formRenderer/fields/implementations/TextField.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Text, TextInput, View } from 'react-native';
+import type { FieldComponentProps } from '../types';
+
+export function TextField({ field, value, onChange, onLayout, readOnly }: FieldComponentProps<string>) {
+  return (
+    <View onLayout={onLayout} style={{ marginBottom: 8 }}>
+      {field.label && <Text style={{ marginBottom: 4 }}>{field.label}</Text>}
+      <TextInput
+        value={value ?? ''}
+        editable={!readOnly}
+        onChangeText={onChange}
+        style={{ borderWidth: 1, borderColor: '#ccc', padding: 4 }}
+      />
+    </View>
+  );
+}

--- a/c365-flow/src/components/formRenderer/fields/implementations/TimeField.tsx
+++ b/c365-flow/src/components/formRenderer/fields/implementations/TimeField.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Text, TextInput, View } from 'react-native';
+import type { FieldComponentProps } from '../types';
+
+export function TimeField({ field, value, onChange, onLayout, readOnly }: FieldComponentProps<string>) {
+  return (
+    <View onLayout={onLayout} style={{ marginBottom: 8 }}>
+      {field.label && <Text style={{ marginBottom: 4 }}>{field.label}</Text>}
+      <TextInput
+        value={value ?? ''}
+        editable={!readOnly}
+        onChangeText={onChange}
+        placeholder="HH:MM"
+        style={{ borderWidth: 1, borderColor: '#ccc', padding: 4 }}
+      />
+    </View>
+  );
+}

--- a/c365-flow/src/components/formRenderer/fields/types.ts
+++ b/c365-flow/src/components/formRenderer/fields/types.ts
@@ -15,3 +15,15 @@ export interface FormSection {
   useModal?: boolean;
   fields: FormField[];
 }
+
+export interface FieldComponentProps<T = any> {
+  fieldKey: string;
+  field: FormField;
+  value: T;
+  onChange: (value: T) => void;
+  onLayout: (e: import('react-native').LayoutChangeEvent) => void;
+  error?: string;
+  readOnly?: boolean;
+  activeDateKey: string | null;
+  setActiveDateKey: React.Dispatch<React.SetStateAction<string | null>>;
+}

--- a/c365-flow/src/components/formRenderer/utils/formUtils.ts
+++ b/c365-flow/src/components/formRenderer/utils/formUtils.ts
@@ -1,3 +1,23 @@
 export function getNestedValue(obj: any, path: (string|number)[]) {
   return path.reduce((acc, key) => (acc == null ? undefined : acc[key as any]), obj);
 }
+
+export function evaluateVisibleWhen(
+  visibleWhen: any,
+  formState: Record<string, any>,
+  localContext?: Record<string, any>
+): boolean {
+  if (!visibleWhen) return true;
+  try {
+    if (typeof visibleWhen === 'function') {
+      return visibleWhen(formState, localContext);
+    }
+    if (visibleWhen.path && 'equals' in visibleWhen) {
+      const value = getNestedValue(formState, String(visibleWhen.path).split('.'));
+      return value === visibleWhen.equals;
+    }
+  } catch {
+    // ignore errors and assume visible
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- replace FieldRenderer with switch-based renderer supporting text, boolean, number, date, and more
- add individual components for each field type
- add evaluateVisibleWhen helper and shared field props

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4edc98ab88328b6377b8b69c8700a