### PR TITLE
Add modal-based select and multiselect fields

### DIFF
--- a/c365-flow/src/components/formRenderer/fields/implementations/MultiSelectField.tsx
+++ b/c365-flow/src/components/formRenderer/fields/implementations/MultiSelectField.tsx
@@ -1,18 +1,79 @@
-import React from 'react';
-import { Text, TextInput, View } from 'react-native';
+import React, { useState, useEffect } from 'react';
+import {
+  Text,
+  View,
+  Modal,
+  TouchableOpacity,
+  ScrollView,
+  Button,
+} from 'react-native';
 import type { FieldComponentProps } from '../types';
+import { styles } from '../../styles';
 
 export function MultiSelectField({ field, value, onChange, onLayout, readOnly }: FieldComponentProps<string[]>) {
-  const joined = Array.isArray(value) ? value.join(', ') : '';
+  const [visible, setVisible] = useState(false);
+  const [selected, setSelected] = useState<string[]>(Array.isArray(value) ? value : []);
+
+  useEffect(() => {
+    setSelected(Array.isArray(value) ? value : []);
+  }, [value]);
+
+  const toggleOption = (option: string) => {
+    setSelected((prev) =>
+      prev.includes(option) ? prev.filter((o) => o !== option) : [...prev, option]
+    );
+  };
+
+  const confirm = () => {
+    onChange(selected);
+    setVisible(false);
+  };
+
+  const open = () => {
+    if (!readOnly) setVisible(true);
+  };
+
+  const display = selected.join(', ');
+
   return (
     <View onLayout={onLayout} style={{ marginBottom: 8 }}>
       {field.label && <Text style={{ marginBottom: 4 }}>{field.label}</Text>}
-      <TextInput
-        value={joined}
-        editable={!readOnly}
-        onChangeText={(t) => onChange(t.split(',').map(s => s.trim()))}
+      <TouchableOpacity
+        onPress={open}
         style={{ borderWidth: 1, borderColor: '#ccc', padding: 4 }}
-      />
+        disabled={readOnly}
+      >
+        <Text>{display || 'Select...'}</Text>
+      </TouchableOpacity>
+      {visible && (
+        <Modal transparent visible onRequestClose={() => setVisible(false)}>
+          <TouchableOpacity
+            style={styles.modalOverlay}
+            activeOpacity={1}
+            onPress={() => setVisible(false)}
+          >
+            <View style={styles.modalContent}>
+              <ScrollView>
+                {Array.isArray(field.options) &&
+                  field.options.map((opt: string) => {
+                    const checked = selected.includes(opt);
+                    return (
+                      <TouchableOpacity
+                        key={opt}
+                        onPress={() => toggleOption(opt)}
+                        style={{ padding: 8, flexDirection: 'row', alignItems: 'center' }}
+                      >
+                        <Text style={{ marginRight: 8 }}>{checked ? '☑' : '☐'}</Text>
+                        <Text>{opt}</Text>
+                      </TouchableOpacity>
+                    );
+                  })}
+              </ScrollView>
+              <Button title="Done" onPress={confirm} />
+            </View>
+          </TouchableOpacity>
+        </Modal>
+      )}
     </View>
   );
 }

--- a/c365-flow/src/components/formRenderer/fields/implementations/SelectField.tsx
+++ b/c365-flow/src/components/formRenderer/fields/implementations/SelectField.tsx
@@ -1,17 +1,56 @@
-import React from 'react';
-import { Text, TextInput, View } from 'react-native';
+import React, { useState } from 'react';
+import {
+  Text,
+  View,
+  Modal,
+  TouchableOpacity,
+  ScrollView,
+  Button,
+} from 'react-native';
 import type { FieldComponentProps } from '../types';
+import { styles } from '../../styles';
 
 export function SelectField({ field, value, onChange, onLayout, readOnly }: FieldComponentProps<string>) {
+  const [visible, setVisible] = useState(false);
+
+  const open = () => {
+    if (!readOnly) setVisible(true);
+  };
+
+  const handleSelect = (option: string) => {
+    onChange(option);
+    setVisible(false);
+  };
+
   return (
     <View onLayout={onLayout} style={{ marginBottom: 8 }}>
       {field.label && <Text style={{ marginBottom: 4 }}>{field.label}</Text>}
-      <TextInput
-        value={value ?? ''}
-        editable={!readOnly}
-        onChangeText={onChange}
+      <TouchableOpacity
+        onPress={open}
         style={{ borderWidth: 1, borderColor: '#ccc', padding: 4 }}
-      />
+        disabled={readOnly}
+      >
+        <Text>{value ?? 'Select...'}</Text>
+      </TouchableOpacity>
+      {visible && (
+        <Modal transparent visible onRequestClose={() => setVisible(false)}>
+          <TouchableOpacity
+            style={styles.modalOverlay}
+            activeOpacity={1}
+            onPress={() => setVisible(false)}
+          >
+            <View style={styles.modalContent}>
+              <ScrollView>
+                {Array.isArray(field.options) &&
+                  field.options.map((opt: string) => (
+                    <Button key={opt} title={opt} onPress={() => handleSelect(opt)} />
+                  ))}
+              </ScrollView>
+              <Button title="Close" onPress={() => setVisible(false)} />
+            </View>
+          </TouchableOpacity>
+        </Modal>
+      )}
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- show select options in a modal so users can choose from schema-provided choices
- allow multi-select fields to toggle multiple options in a modal

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4f1f96b388328963a6330b66c1bb7